### PR TITLE
ECO-3188 [Braintree] SprykerEco/Braintree - Propel/Postgres - foreign key name length issue

### DIFF
--- a/src/SprykerEco/Zed/Braintree/Persistence/Propel/Schema/spy_braintree.schema.xml
+++ b/src/SprykerEco/Zed/Braintree/Persistence/Propel/Schema/spy_braintree.schema.xml
@@ -67,7 +67,7 @@
         <foreign-key name="spy_payment_transaction_order_item-fk_transaction_status_log" foreignTable="spy_payment_braintree_transaction_status_log">
             <reference foreign="id_payment_braintree_transaction_status_log" local="fk_payment_braintree_transaction_status_log"/>
         </foreign-key>
-        <foreign-key name="spy_payment_transaction_order_item-fk_payment_braintree_order_item" foreignTable="spy_payment_braintree_order_item">
+        <foreign-key name="spy_payment_order_item-fk_payment_braintree_order_item" foreignTable="spy_payment_braintree_order_item">
             <reference foreign="id_payment_braintree_order_item" local="fk_payment_braintree_order_item"/>
         </foreign-key>
     </table>


### PR DESCRIPTION
- Developer(s): @SergeBabich

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Braintree             | patch                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Braintree

##### Change log

Bugfixes

* Fixed the spy_payment_transaction_order_item foreign key name length issue

