### PR TITLE
apply braintree plugin only for branitree payment orders

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.bat]
+end_of_line = crlf
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/src/SprykerEco/Zed/Braintree/Communication/Plugin/Checkout/BraintreeCreatePaymentPlugin.php
+++ b/src/SprykerEco/Zed/Braintree/Communication/Plugin/Checkout/BraintreeCreatePaymentPlugin.php
@@ -11,6 +11,7 @@ use Generated\Shared\Transfer\CheckoutResponseTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
 use Spryker\Zed\Checkout\Dependency\Plugin\CheckoutPreSaveHookInterface;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use SprykerEco\Shared\Braintree\BraintreeConfig;
 
 /**
  * @method \SprykerEco\Zed\Braintree\Business\BraintreeFacadeInterface getFacade()
@@ -29,6 +30,10 @@ class BraintreeCreatePaymentPlugin extends AbstractPlugin implements CheckoutPre
      */
     public function preSave(QuoteTransfer $quoteTransfer, CheckoutResponseTransfer $checkoutResponseTransfer)
     {
+        if ($quoteTransfer->getPayment()->getPaymentProvider() !== BraintreeConfig::PROVIDER_NAME) {
+            return $quoteTransfer;
+        }
+
         return $this->getFacade()->createPayment($quoteTransfer, $checkoutResponseTransfer);
     }
 }

--- a/tooling.yml
+++ b/tooling.yml
@@ -1,0 +1,5 @@
+architecture-sniffer:
+    priority: 2
+
+code-sniffer:
+    level: 1


### PR DESCRIPTION
- Developer(s): @DimanKadykov 

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Braintree             | patch                 |                       |

-----------------------------------------

#### Module Braintree

##### Change log

Fixes

* Apply Braintree plugin only for Braintree payment orders
* Bump jquery from 3.4.0 to 3.5.0 in /assets/Yves

