### PR TITLE
SUPESC-200: Braintree Credit Card doesn't work with Apostrophe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "require": {
     "braintree/braintree_php": "^3.0.0",
-    "nette/utils": "^3.0.0",
     "php": ">=7.3",
     "spryker-shop/checkout-page": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "spryker-shop/money-widget": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "require": {
     "braintree/braintree_php": "^3.0.0",
+    "nette/utils": "^3.0.0",
     "php": ">=7.3",
     "spryker-shop/checkout-page": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "spryker-shop/money-widget": "^1.0.0",

--- a/src/SprykerEco/Yves/Braintree/Form/CreditCardSubForm.php
+++ b/src/SprykerEco/Yves/Braintree/Form/CreditCardSubForm.php
@@ -8,13 +8,13 @@
 namespace SprykerEco\Yves\Braintree\Form;
 
 use Generated\Shared\Transfer\BraintreePaymentTransfer;
-use Nette\Utils\Strings;
 use Spryker\Shared\Config\Config;
 use SprykerEco\Shared\Braintree\BraintreeConfig;
 use SprykerEco\Shared\Braintree\BraintreeConstants;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\String\UnicodeString;
 
 class CreditCardSubForm extends AbstractSubForm
 {
@@ -91,8 +91,8 @@ class CreditCardSubForm extends AbstractSubForm
         $view->vars[static::EMAIL] = $quote->getCustomer()->getEmail();
         $view->vars[static::AMOUNT] = $quote->getTotals()->getGrandTotal();
         $view->vars[static::BILLING_ADDRESS] = [
-            static::BILLING_ADDRESS_GIVEN_NAME => Strings::toAscii($quote->getBillingAddress()->getFirstName()),
-            static::BILLING_ADDRESS_SURNAME => Strings::toAscii($quote->getBillingAddress()->getLastName()),
+            static::BILLING_ADDRESS_GIVEN_NAME => $this->convertToGermanAsciiFormat($quote->getBillingAddress()->getFirstName()),
+            static::BILLING_ADDRESS_SURNAME => $this->convertToGermanAsciiFormat($quote->getBillingAddress()->getLastName()),
             static::BILLING_ADDRESS_PHONE_NUMBER => $quote->getBillingAddress()->getPhone(),
             static::BILLING_ADDRESS_STREET_ADDRESS => $quote->getBillingAddress()->getAddress1(),
             static::BILLING_ADDRESS_EXTENDED_ADDRESS => $quote->getBillingAddress()->getAddress2(),
@@ -101,5 +101,17 @@ class CreditCardSubForm extends AbstractSubForm
             static::BILLING_ADDRESS_POSTAL_CODE => $quote->getBillingAddress()->getZipCode(),
             static::BILLING_ADDRESS_COUNTRY_CODE => $quote->getBillingAddress()->getCountry() ? $quote->getBillingAddress()->getCountry()->getIso2Code() : '',
         ];
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    protected function convertToGermanAsciiFormat(string $string): string
+    {
+        return (new UnicodeString($string))
+            ->ascii(['de-ascii'])
+            ->toString();
     }
 }

--- a/src/SprykerEco/Yves/Braintree/Form/CreditCardSubForm.php
+++ b/src/SprykerEco/Yves/Braintree/Form/CreditCardSubForm.php
@@ -8,13 +8,10 @@
 namespace SprykerEco\Yves\Braintree\Form;
 
 use Generated\Shared\Transfer\BraintreePaymentTransfer;
+use Nette\Utils\Strings;
 use Spryker\Shared\Config\Config;
-use Spryker\Shared\Kernel\Store;
-use Spryker\Shared\Money\Dependency\Plugin\MoneyPluginInterface;
 use SprykerEco\Shared\Braintree\BraintreeConfig;
 use SprykerEco\Shared\Braintree\BraintreeConstants;
-use SprykerEco\Yves\Braintree\Dependency\Client\BraintreeToGlossaryClientInterface;
-use SprykerEco\Yves\Braintree\Dependency\Client\BraintreeToShipmentClientInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -86,7 +83,7 @@ class CreditCardSubForm extends AbstractSubForm
         parent::buildView($view, $form, $options);
 
         $view->vars[static::CLIENT_TOKEN] = $this->generateClientToken();
-        $view->vars[static::IS_3D_SECURE] = (string) Config::get(BraintreeConstants::IS_3D_SECURE);
+        $view->vars[static::IS_3D_SECURE] = (string)Config::get(BraintreeConstants::IS_3D_SECURE);
 
         /** @var \Generated\Shared\Transfer\QuoteTransfer $quote */
         $quote = $form->getParent()->getViewData();
@@ -94,8 +91,8 @@ class CreditCardSubForm extends AbstractSubForm
         $view->vars[static::EMAIL] = $quote->getCustomer()->getEmail();
         $view->vars[static::AMOUNT] = $quote->getTotals()->getGrandTotal();
         $view->vars[static::BILLING_ADDRESS] = [
-            static::BILLING_ADDRESS_GIVEN_NAME => $quote->getBillingAddress()->getFirstName(),
-            static::BILLING_ADDRESS_SURNAME => $quote->getBillingAddress()->getLastName(),
+            static::BILLING_ADDRESS_GIVEN_NAME => Strings::toAscii($quote->getBillingAddress()->getFirstName()),
+            static::BILLING_ADDRESS_SURNAME => Strings::toAscii($quote->getBillingAddress()->getLastName()),
             static::BILLING_ADDRESS_PHONE_NUMBER => $quote->getBillingAddress()->getPhone(),
             static::BILLING_ADDRESS_STREET_ADDRESS => $quote->getBillingAddress()->getAddress1(),
             static::BILLING_ADDRESS_EXTENDED_ADDRESS => $quote->getBillingAddress()->getAddress2(),

--- a/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
+++ b/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
@@ -87,11 +87,37 @@ class CreditCardSubFormTest extends Unit
         $view = $this->buildCreditCardSubForm($quoteTransfer);
 
         $this->assertSame(
-            'Soniua',
+            'Soniuea',
             $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_GIVEN_NAME]
         );
         $this->assertSame(
             'WDagner',
+            $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_SURNAME]
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildCreditCardSubFormConvertCustomerGermanNames(): void
+    {
+        $addressTransfer = (new AddressBuilder())->build()
+            ->setFirstName('Herr')
+            ->setLastName('Müßig');
+
+        $quoteTransfer = (new QuoteTransfer())
+            ->setCustomer((new CustomerBuilder())->build())
+            ->setTotals((new TotalsTransfer())->setGrandTotal(666))
+            ->setBillingAddress($addressTransfer);
+
+        $view = $this->buildCreditCardSubForm($quoteTransfer);
+
+        $this->assertSame(
+            'Herr',
+            $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_GIVEN_NAME]
+        );
+        $this->assertSame(
+            'Muessig',
             $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_SURNAME]
         );
     }
@@ -113,7 +139,7 @@ class CreditCardSubFormTest extends Unit
         $view = $this->buildCreditCardSubForm($quoteTransfer);
 
         $this->assertSame(
-            'KoBu',
+            'KoBue',
             $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_GIVEN_NAME]
         );
         $this->assertSame(

--- a/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
+++ b/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
@@ -43,6 +43,7 @@ class CreditCardSubFormTest extends Unit
         parent::setUp();
 
         $this->tester->setConfig(BraintreeConstants::FAKE_CLIENT_TOKEN, 'FAKE_CLIENT_TOKEN');
+        $this->tester->setConfig(BraintreeConstants::IS_3D_SECURE, false);
     }
 
     /**

--- a/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
+++ b/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
@@ -42,7 +42,7 @@ class CreditCardSubFormTest extends Unit
     {
         parent::setUp();
 
-        $this->setupConfig();
+        $this->tester->setConfig(BraintreeConstants::FAKE_CLIENT_TOKEN, 'FAKE_CLIENT_TOKEN');
     }
 
     /**
@@ -134,16 +134,5 @@ class CreditCardSubFormTest extends Unit
             ->create(CreditCardSubForm::class, new BraintreePaymentTransfer(), ['select_options' => []])
             ->setParent($formFactory->create(FakeParentForm::class, $quoteTransfer))
             ->createView();
-    }
-
-    /**
-     * @return void
-     */
-    protected function setupConfig(): void
-    {
-        $this->tester->setConfig(BraintreeConstants::ENVIRONMENT, 'sandbox');
-        $this->tester->setConfig(BraintreeConstants::MERCHANT_ID, 'cwd5zrcngwjmrfvg');
-        $this->tester->setConfig(BraintreeConstants::PUBLIC_KEY, '6qpxzjnwqbnnsfyt');
-        $this->tester->setConfig(BraintreeConstants::PRIVATE_KEY, '31d6202353068944bbceba4794cb7013');
     }
 }

--- a/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
+++ b/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerEcoTest\Yves\Braintree\Business;
+
+use Codeception\Test\Unit;
+use Generated\Shared\DataBuilder\AddressBuilder;
+use Generated\Shared\DataBuilder\CustomerBuilder;
+use Generated\Shared\Transfer\BraintreePaymentTransfer;
+use Generated\Shared\Transfer\QuoteTransfer;
+use Generated\Shared\Transfer\TotalsTransfer;
+use SprykerEco\Yves\Braintree\Form\CreditCardSubForm;
+use SprykerEcoTest\Yves\Braintree\Form\FakeParentForm;
+use Symfony\Component\Form\FormView;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerEcoTest
+ * @group Yves
+ * @group Braintree
+ * @group Business
+ * @group CreditCardSubFormTest
+ * Add your own group annotations below this line
+ */
+class CreditCardSubFormTest extends Unit
+{
+    /**
+     * @var \SprykerEcoTest\Yves\Braintree\BraintreeBusinessTester
+     */
+    protected $tester;
+
+    /**
+     * @return void
+     */
+    public function testBuildCreditCardSubFormForCustomerWithoutNonAsciiChars(): void
+    {
+        $addressTransfer = (new AddressBuilder())->build();
+
+        $quoteTransfer = (new QuoteTransfer())
+            ->setCustomer((new CustomerBuilder())->build())
+            ->setTotals((new TotalsTransfer())->setGrandTotal(666))
+            ->setBillingAddress($addressTransfer);
+
+        $view = $this->buildCreditCardSubForm($quoteTransfer);
+
+        $this->assertSame(
+            $addressTransfer->getFirstName(),
+            $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_GIVEN_NAME]
+        );
+        $this->assertSame(
+            $addressTransfer->getLastName(),
+            $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_SURNAME]
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildCreditCardSubFormForCustomerWithNonAsciiChars(): void
+    {
+        $addressTransfer = (new AddressBuilder())->build()
+            ->setFirstName('Soniüa')
+            ->setLastName('WΔagner');
+
+        $quoteTransfer = (new QuoteTransfer())
+            ->setCustomer((new CustomerBuilder())->build())
+            ->setTotals((new TotalsTransfer())->setGrandTotal(666))
+            ->setBillingAddress($addressTransfer);
+
+        $view = $this->buildCreditCardSubForm($quoteTransfer);
+
+        $this->assertSame(
+            'Soniua',
+            $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_GIVEN_NAME]
+        );
+        $this->assertSame(
+            'WDagner',
+            $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_SURNAME]
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildCreditCardSubFormForCustomerWithFullNonAsciiChars(): void
+    {
+        $addressTransfer = (new AddressBuilder())->build()
+            ->setFirstName('ΚοΒü')
+            ->setLastName('ΑƒƒΔΨ');
+
+        $quoteTransfer = (new QuoteTransfer())
+            ->setCustomer((new CustomerBuilder())->build())
+            ->setTotals((new TotalsTransfer())->setGrandTotal(666))
+            ->setBillingAddress($addressTransfer);
+
+        $view = $this->buildCreditCardSubForm($quoteTransfer);
+
+        $this->assertSame(
+            'KoBu',
+            $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_GIVEN_NAME]
+        );
+        $this->assertSame(
+            'AffDPS',
+            $view->vars[CreditCardSubForm::BILLING_ADDRESS][CreditCardSubForm::BILLING_ADDRESS_SURNAME]
+        );
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
+     * @return \Symfony\Component\Form\FormView
+     */
+    protected function buildCreditCardSubForm(QuoteTransfer $quoteTransfer): FormView
+    {
+        $formFactory = $this->tester->getFormFactory();
+
+        return $formFactory
+            ->create(CreditCardSubForm::class, new BraintreePaymentTransfer(), ['select_options' => []])
+            ->setParent($formFactory->create(FakeParentForm::class, $quoteTransfer))
+            ->createView();
+    }
+}

--- a/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
+++ b/tests/SprykerEcoTest/Yves/Braintree/Business/CreditCardSubFormTest.php
@@ -13,6 +13,7 @@ use Generated\Shared\DataBuilder\CustomerBuilder;
 use Generated\Shared\Transfer\BraintreePaymentTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
 use Generated\Shared\Transfer\TotalsTransfer;
+use SprykerEco\Shared\Braintree\BraintreeConstants;
 use SprykerEco\Yves\Braintree\Form\CreditCardSubForm;
 use SprykerEcoTest\Yves\Braintree\Form\FakeParentForm;
 use Symfony\Component\Form\FormView;
@@ -33,6 +34,16 @@ class CreditCardSubFormTest extends Unit
      * @var \SprykerEcoTest\Yves\Braintree\BraintreeBusinessTester
      */
     protected $tester;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setupConfig();
+    }
 
     /**
      * @return void
@@ -123,5 +134,16 @@ class CreditCardSubFormTest extends Unit
             ->create(CreditCardSubForm::class, new BraintreePaymentTransfer(), ['select_options' => []])
             ->setParent($formFactory->create(FakeParentForm::class, $quoteTransfer))
             ->createView();
+    }
+
+    /**
+     * @return void
+     */
+    protected function setupConfig(): void
+    {
+        $this->tester->setConfig(BraintreeConstants::ENVIRONMENT, 'sandbox');
+        $this->tester->setConfig(BraintreeConstants::MERCHANT_ID, 'cwd5zrcngwjmrfvg');
+        $this->tester->setConfig(BraintreeConstants::PUBLIC_KEY, '6qpxzjnwqbnnsfyt');
+        $this->tester->setConfig(BraintreeConstants::PRIVATE_KEY, '31d6202353068944bbceba4794cb7013');
     }
 }

--- a/tests/SprykerEcoTest/Yves/Braintree/_support/BraintreeBusinessTester.php
+++ b/tests/SprykerEcoTest/Yves/Braintree/_support/BraintreeBusinessTester.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerEcoTest\Yves\Braintree;
+
+use Codeception\Actor;
+use Symfony\Component\Form\FormFactoryBuilder;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+ */
+class BraintreeBusinessTester extends Actor
+{
+    use _generated\BraintreeBusinessTesterActions;
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Form\FormFactoryInterface
+     */
+    public function getFormFactory(): FormFactoryInterface
+    {
+        return (new FormFactoryBuilder())->getFormFactory();
+    }
+}

--- a/tests/SprykerEcoTest/Yves/Braintree/_support/Form/FakeParentForm.php
+++ b/tests/SprykerEcoTest/Yves/Braintree/_support/Form/FakeParentForm.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerEcoTest\Yves\Braintree\Form;
+
+use Symfony\Component\Form\AbstractType;
+
+class FakeParentForm extends AbstractType
+{
+}

--- a/tests/SprykerEcoTest/Yves/Braintree/codeception.yml
+++ b/tests/SprykerEcoTest/Yves/Braintree/codeception.yml
@@ -20,6 +20,7 @@ suites:
             enabled:
                 - Asserts
                 - \SprykerTest\Shared\Testify\Helper\Environment
+                - \SprykerTest\Shared\Testify\Helper\ConfigHelper
 
     Presentation:
         path: Presentation

--- a/tests/SprykerEcoTest/Yves/Braintree/codeception.yml
+++ b/tests/SprykerEcoTest/Yves/Braintree/codeception.yml
@@ -13,6 +13,14 @@ coverage:
     whitelist: { include: ['../../../../src/*'] }
 
 suites:
+    Business:
+        path: Business
+        class_name: BraintreeBusinessTester
+        modules:
+            enabled:
+                - Asserts
+                - \SprykerTest\Shared\Testify\Helper\Environment
+
     Presentation:
         path: Presentation
         class_name: BraintreePresentationTester

--- a/tests/_data/braintree.databuilder.xml
+++ b/tests/_data/braintree.databuilder.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<transfers
+    xmlns="spryker:databuilder-01"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="spryker:databuilder-01 http://static.spryker.com/databuilder-01.xsd"
+>
+
+    <transfer name="Customer">
+        <property name="email" dataBuilderRule="unique()->email"/>
+    </transfer>
+
+    <transfer name="Address">
+        <property name="salutation" dataBuilderRule="randomElement(['Mr', 'Mrs'])"/>
+        <property name="firstName" dataBuilderRule="firstName"/>
+        <property name="lastName" dataBuilderRule="lastName"/>
+        <property name="address1" dataBuilderRule="address"/>
+        <property name="address2" dataBuilderRule="address"/>
+        <property name="address3" dataBuilderRule="address"/>
+        <property name="company" dataBuilderRule="company"/>
+        <property name="city" dataBuilderRule="city"/>
+        <property name="zipCode" dataBuilderRule="postcode"/>
+        <property name="state" dataBuilderRule="country"/>
+        <property name="iso2Code" dataBuilderRule="=DE"/>
+    </transfer>
+
+</transfers>


### PR DESCRIPTION
- Developer(s): @dmiseev

- Ticket: https://spryker.atlassian.net/browse/SUPESC-200


#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Braintree             | patch                 |                       |

-----------------------------------------

#### Module Braintree

##### Change log

Fixes

- Adjusted `CreditCardSubForm` in order to convert billing `firstName` and `lastName` to ASCII format.

